### PR TITLE
Bug Fixed en addProduct

### DIFF
--- a/Client/src/views/addProduct/addProduct.jsx
+++ b/Client/src/views/addProduct/addProduct.jsx
@@ -231,6 +231,10 @@ setErrors({ ...errors, [name]: error });
         selectedCategory === ""
       ) {
         alert("Todos los campos marcados con * son obligatorios");
+        setFormData({
+          ...formData,
+          disabled: false,
+        })  
         return;
       }
       setErrors(errors);
@@ -292,6 +296,10 @@ setErrors({ ...errors, [name]: error });
         console.log("Hubo un error al crear la publicación.");
       }
     } catch (error) {
+      setFormData({
+        ...formData,
+        disabled: false,
+      })
       console.error("Error al enviar los datos al servidor:", error);
       console.log("Hubo un error al crear la publicación.");
     }


### PR DESCRIPTION
Bug en addProduct **corregido:**

* Cuando se intentaba crear una publicación con campos faltantes, aparecía el spinner y de deshabilitaban los campos haciendo que no se pueda continuar con la creación del post a menos que se recargue la página.