### PR TITLE
BugFixed Spinner en Register

### DIFF
--- a/Client/src/components/register/Register.jsx
+++ b/Client/src/components/register/Register.jsx
@@ -159,6 +159,10 @@ const Register = ({setAuth}) => {
     !localidad
   ) {
     alert('Complete todos los campos antes de enviar el formulario.');
+    setInput({
+      ...input,
+      disabled: false,
+    })
     return;
   }
 
@@ -213,6 +217,11 @@ const Register = ({setAuth}) => {
       title: 'Error al registrar',
       text: 'Hubo un error al registrar el usuario. Por favor, inténtalo de nuevo.',
     });
+    setInput({
+      ...input,
+      disabled: false,
+    })
+    return
   }
 
   setInput({


### PR DESCRIPTION
Se corrigió el mismo bug del spinner que en addProduct. Cuando se clickeaba el botón de 'Crear' si había un error o faltaban campos, el spinner quedaba cargando y los campos se deshabilitaban haciendo imposible continuar con el registro. Además, se añadió un return para que, en caso de error, los campos no se reinicien para no tener que ingresar la info desde 0.